### PR TITLE
fix: add appcompat theme to audio recorder

### DIFF
--- a/src/android/AudioRecorder.java
+++ b/src/android/AudioRecorder.java
@@ -176,6 +176,7 @@ public class AudioRecorder extends AppCompatActivity {
 		packageName = this.getPackageName();
 		int activityMainId = activityRes.getIdentifier("activity_main", "layout", packageName);
 		setRequestedOrientation(ActivityInfo.SCREEN_ORIENTATION_PORTRAIT);
+		setTheme(R.Style.AppTheme);
 		setContentView(activityMainId);
 		setTitle("Audio Recorder");
 

--- a/src/android/res/values/themes.xml
+++ b/src/android/res/values/themes.xml
@@ -1,3 +1,3 @@
 <resources>
-	<style name="AppTheme" parent="@android:style/Theme.Black" />
+	<style name="AppTheme" parent="Theme.AppCompat.NoActionBar" />
 </resources>


### PR DESCRIPTION
android was throwing an error because it requires an AppCompat theme.
Ive changed the parent of AppTheme to an AppCompat theme and set the theme before the contentView is set.